### PR TITLE
Fixes & Improvements

### DIFF
--- a/sc-iavm/api/modules/sc.api.core/sc_api_modules/sc.auditfile.psm1
+++ b/sc-iavm/api/modules/sc.api.core/sc_api_modules/sc.auditfile.psm1
@@ -10,8 +10,8 @@ function SC-Get-AuditFiles() {
         https://docs.tenable.com/sccv/api/AuditFile.html
     #>
     param(
-        [ValidateSet("usable","managable","usable,managable")]
-          [string]$filter = "usable,managable",
+        [ValidateSet("usable","manageable","usable,manageable")]
+          [string]$filter = "usable,manageable",
         [switch]$name,
         [switch]$description,
         [switch]$type,

--- a/sc-iavm/api/modules/sc.api.core/sc_api_modules/sc.policy.psm1
+++ b/sc-iavm/api/modules/sc.api.core/sc_api_modules/sc.policy.psm1
@@ -17,8 +17,8 @@ function SC-Get-ScanPolicy() {
     #>
     param(
         [switch]$name,
-        [ValidateSet("usable","managable","usable,managable")]
-          [string]$filter = "usable,managable",
+        [ValidateSet("usable","manageable","usable,manageable")]
+          [string]$filter = "usable,manageable",
         [switch]$description,
         [switch]$status,
         [switch]$policyTemplate,

--- a/sc-iavm/api/modules/sc.api.core/sc_api_modules/sc.reports.psm1
+++ b/sc-iavm/api/modules/sc.api.core/sc_api_modules/sc.reports.psm1
@@ -15,8 +15,8 @@ function SC-Get-Reports() {
         Note: Undocumented endpoint, either in the SCCV or Cerberus variant of the API links
     #>
     param(
-        [ValidateSet("usable","managable","usable,managable")]
-          [string]$filter = "usable,managable",
+        [ValidateSet("usable","manageable","usable,manageable")]
+          [string]$filter = "usable,manageable",
         [switch]$name,
         [switch]$description,
         [switch]$type,

--- a/sc-iavm/api/modules/sc.api.core/sc_api_modules/sc.scan.psm1
+++ b/sc-iavm/api/modules/sc.api.core/sc_api_modules/sc.scan.psm1
@@ -33,15 +33,15 @@ function SC-Get-ScanInfo() {
         Parameters:
           - id: Integer; If specified, only retrieve information about the scan with the ID number given.
               otherwise, retrieve all scans' info.
-          - filter: Only retrieve usable, managable, or both usable and managable scans. Defaults
-              to both usable and managable scans returned.
+          - filter: Only retrieve usable, manageable, or both usable and manageable scans. Defaults
+              to both usable and manageable scans returned.
           - getAllInfo: Switch; if specified, sets all switches to True to return all info
     #>
     param (
         [ValidatePattern("^\d+$")]
           [int]$id = 0,
-        [ValidateSet("usable","managable","usable,managable")]
-          [string]$filter = "usable,managable",
+        [ValidateSet("usable","manageable","usable,manageable")]
+          [string]$filter = "usable,manageable",
         [switch]$name,
         [switch]$description,
         [switch]$status,
@@ -414,7 +414,7 @@ function SC-Edit-Scan() {
 
 function SC-Get-RolloverScans() {
     <# Find any rollover scans #>
-    $resp = SC-Get-ScanInfo -filter managable -name -schedule -ownerGroup -owner -createdTime
+    $resp = SC-Get-ScanInfo -filter manageable -name -schedule -ownerGroup -owner -createdTime
     return $resp.response.manageable | Where-Object { $_.schedule.type -eq "rollover" }
 }
 

--- a/sc-iavm/api/modules/sc.api.core/sc_api_modules/sc.scanResult.psm1
+++ b/sc-iavm/api/modules/sc.api.core/sc_api_modules/sc.scanResult.psm1
@@ -21,8 +21,8 @@ function SC-Get-ScanResults() {
     param(
         [ValidateScript({$_ -ge 0})]
           [int]$scanResultID = $null,
-        [ValidateSet("usable", "manageable", "usable,managable")]
-          [string]$filterAccess = "usable,managable",
+        [ValidateSet("usable", "manageable", "usable,manageable")]
+          [string]$filterAccess = "usable,manageable",
         [ValidateSet("running", "completed", "running,completed")]
           [string]$filterStatus = "running,completed",
         [switch]$name,

--- a/sc-iavm/misc/Auto-Purge Target IPs.ps1
+++ b/sc-iavm/misc/Auto-Purge Target IPs.ps1
@@ -37,7 +37,7 @@ function Read-ConfigFile {
         $script:uri = ($conf | ConvertFrom-Json).uri
     }
     else {
-        while ($uri -eq $null) {
+        while ($uri -eq "") {
             $input = Read-Host -Prompt "Provide the SecurityCenter URI, no trailing slash"
             if (($input -like "https://*") -and ($input -notlike "https://*/")) {
                 $script:uri = $input

--- a/sc-iavm/misc/Auto-Purge Target IPs.ps1
+++ b/sc-iavm/misc/Auto-Purge Target IPs.ps1
@@ -130,9 +130,20 @@ $chosenCertThumb = Invoke-CertificateChooser
 
 SC-Authenticate -pkiThumbprint $chosenCertThumb -uri $uri | Out-Null
 
+# Get a listing of the repositories and prompt for which to use
+$resp = SC-Get-Repositories -type Local -name
+$repos = @()
+foreach ($repo in $resp.response) {
+    $repos += [int]$repo.id
+    Write-Host "[" $repo.id "] - " $repo.name
+}
+[int]$repository_selected = Read-Host -Prompt "Enter the repository number to purge data from; other values exit."
+if ($repository_selected -notin $repos) {
+    Write-Host -ForegroundColor Red "Invalid option selected; terminating execution..."
+    exit
+}
 
 # Then process the IP purge request...
-
 # Get the XML data...
 Write-Host -ForegroundColor Yellow "Give me the removeip.nessus template..."
 $path = Get-FileName -initialDirectory (Get-Location) -filter "Nessus Results File (*.nessus)| *.nessus"
@@ -220,7 +231,7 @@ Remove-Item $nessus_output_filename
 $sc_uploaded_filename = SC-Upload-File -filePath $zip_output_filename
 
 # Then issue the command to import it.
-$resp = SC-Import-NessusResults -generatedFilename $sc_uploaded_filename -repositoryID 7
+$resp = SC-Import-NessusResults -generatedFilename $sc_uploaded_filename -repositoryID $repository_selected
 
 # Did the upload complete successfully?
 if ($resp.error_code -eq 0) {

--- a/sc-iavm/misc/Backup SecurityCenter Information.ps1
+++ b/sc-iavm/misc/Backup SecurityCenter Information.ps1
@@ -344,6 +344,6 @@ $repositories_storage | ConvertTo-Csv -NoTypeInformation | Out-File repository_i
 Write-Host -ForegroundColor Green "Exported SecurityCenter repository information."
 
 Pop-Location
-SC-Logout
+SC-Logout | Out-Null
 
 Write-Host -ForegroundColor Green "~~~~~ Information Export Complete ~~~~~"

--- a/sc-iavm/misc/Backup SecurityCenter Information.ps1
+++ b/sc-iavm/misc/Backup SecurityCenter Information.ps1
@@ -70,6 +70,7 @@ $directoryName = (Get-Date -Format yyyyMMdd) + "_SCBackup"
 New-Item -ItemType Directory -Name $directoryName | Out-Null
 Push-Location $directoryName
 
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 # ##### Extract group information #####
 $resp_groups = SC-Get-GroupInformation -name -repositories -description -definingAssets -users
@@ -100,6 +101,7 @@ foreach($group in $resp_groups.response) {
 $group_storage | ConvertTo-Csv -NoTypeInformation | Out-File group_information_export.csv
 Write-Host -ForegroundColor Green "Exported SecurityCenter group information."
 
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 # ##### Extract user information #####
 $resp_users = SC-Get-User -firstname -lastname -address -authType -city -country -email -failedLogins -fingerprint -group -lastLogin -locked -managedObjectsGroups -managedUsersGroups -createdTime -modifiedTime -mustChangePassword -phone -responsibleAsset -role -state -status -title -username -canManage -canUse
@@ -134,17 +136,18 @@ foreach($user in $resp_users.response) {
 $user_storage | ConvertTo-Csv -NoTypeInformation | Out-File user_information_export.csv
 Write-Host -ForegroundColor Green "Exported SecurityCenter user information."
 
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 # ##### Extract scan information #####
 # SC API BUG: Using ipList against the /scan endpoint does not return a CSV-list of IPs. Use ``SC-Get-ScanInfo -id $ID`` instead
 #   > ipList from /scan itself: 10.10.0.010.10.0.110.10.0.2
 #   > ipList from /scan/<id>: 10.10.0.0,10.10.0.1,10.10.0.2
-$resp_scans = SC-Get-ScanInfo -filter usable -name -description -type -policy -repository -zone -owner -schedule -assets -credentials
+$resp_scans = SC-Get-ScanInfo -filter manageable -name -description -type -policy -repository -zone -owner -schedule -assets -credentials -ownerGroup
 
 $scan_storage = @()
 $currProgress = 0
-foreach ($scan in $resp_scans.response.usable) {
-    Write-Progress -Activity "Downloading scan information..." -CurrentOperation ("Getting info for Scan ID#" + $scan.id) -PercentComplete (($currProgress++ / $resp_scans.response.usable.Count) * 100)
+foreach ($scan in $resp_scans.response.manageable) {
+    Write-Progress -Activity "Downloading scan information..." -CurrentOperation ("Getting info for Scan ID#" + $scan.id) -PercentComplete (($currProgress++ / $resp_scans.response.manageable.Count) * 100)
     
     # Get the ipList for the current scan (bug avoidance in the base /scan endpoint)
     $scan_resp = SC-Get-ScanInfo -id $scan.id -ipList
@@ -167,6 +170,7 @@ foreach ($scan in $resp_scans.response.usable) {
         "zone" = $scan.zone.name;
         "schedule" = ($scan.schedule | ConvertTo-Json -Depth 20 -Compress).Replace('"',"'");
         "owner" = $scan.owner.username;
+        "owner_group" = $scan.ownerGroup.name;
         "credentials" = $credentials;
     }
 
@@ -176,9 +180,10 @@ foreach ($scan in $resp_scans.response.usable) {
 $scan_storage | ConvertTo-Csv -NoTypeInformation | Out-File scan_information_export.csv
 Write-Host -ForegroundColor Green "Exported SecurityCenter scan information."
 
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 # ##### Extract scan policies / download #####
-$resp_scan_policies = SC-Get-ScanPolicy -filter usable -name -description -auditFiles -owner -groups
+$resp_scan_policies = SC-Get-ScanPolicy -filter manageable -name -description -auditFiles -owner -groups -ownerGroup
 
 # Since we're dumping a bunch of XML files, make a separate folder
 New-Item -ItemType Directory -Name "scanPolicies" | Out-Null
@@ -188,8 +193,8 @@ $basePath = (Get-Location).Path + '\'
 
 $scan_policy_storage = @()
 $currProgress = 0
-foreach ($policy in $resp_scan_policies.response.usable) {
-    Write-Progress -Activity "Downloading scan policy information..." -CurrentOperation ("Getting info for Scan Policy ID#" + $policy.id) -PercentComplete (($currProgress++ / $resp_scan_policies.response.usable.Count) * 100)
+foreach ($policy in $resp_scan_policies.response.manageable) {
+    Write-Progress -Activity "Downloading scan policy information..." -CurrentOperation ("Getting info for Scan Policy ID#" + $policy.id) -PercentComplete (($currProgress++ / $resp_scan_policies.response.manageable.Count) * 100)
 
     if ($policy.groups -ne $null) {
         $groups = [String]::Join("; ", $policy.groups.name)
@@ -203,6 +208,7 @@ foreach ($policy in $resp_scan_policies.response.usable) {
         "name" = $policy.name;
         "description" = $policy.description -replace '[\n\r]';
         "owner" = $policy.owner.username;
+        "owner_group" = $policy.ownerGroup.name;
         "assigned_groups" = $groups;
         "audit_files" = $auditFiles;
     }
@@ -210,7 +216,12 @@ foreach ($policy in $resp_scan_policies.response.usable) {
     # Get and save out the XML file
     [xml]$resp = SC-Export-ScanPolicy -scanPolicyID $policy.id
     $output_filename = Remove-InvalidFilenameCharacters -name ("scanPolicy_" + $policy.id + " - " + $policy.name + ".xml")
-    $resp.Save($basePath + $output_filename)
+    # Create a directory per group, and then save the file according to the group
+    $zGrpName = Remove-InvalidFilenameCharacters -name $policy.ownerGroup.name
+    if (!(Test-Path -LiteralPath ($basePath + $zGrpName + "\"))) {
+        New-Item -ItemType Directory -Path ($basePath + $zGrpName) | Out-Null
+    }
+    $resp.Save($basePath + $zGrpName + "\" + $output_filename)
 
     Start-Sleep -Milliseconds $request_throttle_msec  # Throttle the requests, somewhat
 }
@@ -220,9 +231,10 @@ Pop-Location
 $scan_policy_storage | ConvertTo-Csv -NoTypeInformation | Out-File scanPolicy_information_export.csv
 Write-Host -ForegroundColor Green "Exported SecurityCenter scan policy information."
 
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 # ##### Extract report information / Download report templates #####
-$resp_reports = SC-Get-Reports -filter usable -name -description -owner -schedule -type -emailTargets -emailUsers
+$resp_reports = SC-Get-Reports -filter 'usable,manageable' -name -description -owner -schedule -type -emailTargets -emailUsers -ownerGroup
 
 # Since we're dumping a bunch of XML files, make a separate folder
 New-Item -ItemType Directory -Name "reportTemplates" | Out-Null
@@ -231,10 +243,8 @@ Push-Location "reportTemplates"
 $basePath = (Get-Location).Path + '\'
 
 $report_storage = @()
-$currProgress = 0
-foreach ($report in $resp_reports.response.usable) {
-    Write-Progress -Activity "Downloading report information..." -CurrentOperation ("Getting info for Report ID#" + $report.id) -PercentComplete (($currProgress++ / $resp_reports.response.usable.Count) * 100)
-
+foreach ($report in $resp_reports.response.manageable) {
+    # Save all report information for all reports (Managable and Usable)
     if ($report.groups -ne $null) {
         $emailUsers = [String]::Join("; ", $report.emailUsers.username)
     } else { $emailUsers = "--NO USER EMAIL SELECTED--" }
@@ -242,6 +252,7 @@ foreach ($report in $resp_reports.response.usable) {
     $report_storage += [pscustomobject]@{
         "id" = $report.id;
         "owner" = $report.owner.username;
+        "owner_group" = $report.ownerGroup.name;
         "name" = $report.name;
         # Carriage returns break Excel cells (because of course they do); replace newline and carriage returns
         "description" = $report.description -replace '[\n\r]';
@@ -250,11 +261,26 @@ foreach ($report in $resp_reports.response.usable) {
         "emailUsers" = $emailUsers;
         "emailTargets" = $report.emailTargets;
     }
+}
+
+$currProgress = 0
+foreach ($report in $resp_reports.response.usable) {
+    # In their infinite wisdom, Tenable blocks exporting templates, UNLESS you:
+    # a) Own the report; or
+    # b) Are in the same group as the report owner.
+    # So just export our reports, then.
 
     # Download the report teplates as a full export with references
+    Write-Progress -Activity "Downloading report information..." -CurrentOperation ("Getting info for Report ID#" + $report.id) -PercentComplete (($currProgress++ / $resp_reports.response.usable.Count) * 100)
+
     [xml]$resp = SC-Export-ReportDefinition -reportID $report.id -type full
     $output_filename = Remove-InvalidFilenameCharacters -name ("reportTemplateWithRefs_" + $report.id + " - " + $report.name + ".xml")
-    $resp.Save($basePath + $output_filename)
+    # Create a directory per group, and then save the file according to the group
+    $zGrpName = Remove-InvalidFilenameCharacters -name $report.ownerGroup.name
+    if (!(Test-Path -LiteralPath ($basePath + $zGrpName + "\"))) {
+        New-Item -ItemType Directory -Path ($basePath + $zGrpName) | Out-Null
+    }
+    $resp.Save($basePath + $zGrpName + "\" + $output_filename)
 
     Start-Sleep -Milliseconds $request_throttle_msec  # Throttle the requests, somewhat
 }
@@ -264,9 +290,10 @@ Pop-Location
 $report_storage | ConvertTo-Csv -NoTypeInformation | Out-File report_information_export.csv
 Write-Host -ForegroundColor Green "Exported SecurityCenter report information."
 
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 # ##### Extract asset lists information / Download asset list XML files #####
-$resp_assets = SC-Get-AssetList -name -description -owner -groups
+$resp_assets = SC-Get-AssetList -name -description -owner -groups -ownerGroup
 
 # Since we're dumping a bunch of XML files, make a separate folder
 New-Item -ItemType Directory -Name "assetLists" | Out-Null
@@ -276,11 +303,11 @@ $basePath = (Get-Location).Path + '\'
 
 $asset_storage = @()
 $currProgress = 0
-foreach ($asset in $resp_assets.response.usable) {
+foreach ($asset in $resp_assets.response.manageable) {
     # ID zero (0) is /technically/ an asset; but it is 'All Defined Ranges'; skip it.
     if ($asset.id -eq 0) { continue; }
 
-    Write-Progress -Activity "Downloading asset list information..." -CurrentOperation ("Getting info for Asset ID#" + $asset.id) -PercentComplete (($currProgress++ / $resp_assets.response.usable.Count) * 100)
+    Write-Progress -Activity "Downloading asset list information..." -CurrentOperation ("Getting info for Asset ID#" + $asset.id) -PercentComplete (($currProgress++ / $resp_assets.response.manageable.Count) * 100)
 
     if ($asset.groups -ne $null) {
         $groups = [String]::Join("; ", $asset.groups.name)
@@ -290,6 +317,7 @@ foreach ($asset in $resp_assets.response.usable) {
         "id" = $asset.id;
         "name" = $asset.name;
         "owner" = $asset.owner.name;
+        "owner_group" = $asset.ownerGroup.name;
         "groups" = $groups;
         "description" = $asset.description -replace '[\n\r]';
     }
@@ -297,7 +325,12 @@ foreach ($asset in $resp_assets.response.usable) {
     # Download the asset list template
     [xml]$resp = SC-Export-AssetList -assetListID $asset.id
     $output_filename = Remove-InvalidFilenameCharacters -name ("assetList_" + $asset.id + " - " + $asset.name + ".xml")
-    $resp.Save($basePath + $output_filename)
+    # Create a directory per group, and then save the file according to the group
+    $zGrpName = Remove-InvalidFilenameCharacters -name $asset.ownerGroup.name
+    if (!(Test-Path -LiteralPath ($basePath + $zGrpName + "\"))) {
+        New-Item -ItemType Directory -Path ($basePath + $zGrpName) | Out-Null
+    }
+    $resp.Save($basePath + $zGrpName + "\" + $output_filename)
 
     Start-Sleep -Milliseconds $request_throttle_msec  # Throttle the requests, somewhat
 }
@@ -307,6 +340,7 @@ Pop-Location
 $asset_storage | ConvertTo-Csv -NoTypeInformation | Out-File assetList_information_export.csv
 Write-Host -ForegroundColor Green "Exported SecurityCenter asset list information."
 
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 # ##### Extract scan zone information #####
 $resp_scanZones = SC-Get-ScanZone -name -description -ipList
@@ -324,6 +358,7 @@ foreach ($zone in $resp_scanZones.response) {
 $scanZone_storage | ConvertTo-Csv -NoTypeInformation | Out-File scanZone_information_export.csv
 Write-Host -ForegroundColor Green "Exported SecurityCenter scan zone information."
 
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 # ##### Extract repository information #####
 $resp_repositories = SC-Get-Repositories -type All -name -description -dataFormat -typeFields
@@ -342,6 +377,8 @@ foreach ($repo in $resp_repositories.response) {
 # Write out the repository information
 $repositories_storage | ConvertTo-Csv -NoTypeInformation | Out-File repository_information_export.csv
 Write-Host -ForegroundColor Green "Exported SecurityCenter repository information."
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Pop-Location
 SC-Logout | Out-Null

--- a/sc-iavm/misc/Backup SecurityCenter Information.ps1
+++ b/sc-iavm/misc/Backup SecurityCenter Information.ps1
@@ -34,7 +34,7 @@ function Read-ConfigFile {
         $script:uri = ($conf | ConvertFrom-Json).uri
     }
     else {
-        while ($uri -eq $null) {
+        while ($script:uri -eq "") {
             $input = Read-Host -Prompt "Provide the SecurityCenter URI, no trailing slash"
             if (($input -like "https://*") -and ($input -notlike "https://*/")) {
                 $script:uri = $input


### PR DESCRIPTION
Because what is ``managable``, anyway? Not a word, that's what.

Also, fix some logic detection in the portions checking for the ``sc.conf`` file.

And also improve the SC backup script. Dump as much as we can (``manageable`` vs. ``usable``), because why not. Also discovered, the ``Full Access`` group can't fully dump all reports. Only those reports which you own or those of users in the authenticated user's group. Attempting to dump ``manageable`` templates will (as of this point in time), yield an error such as the following:

```
{"type":"regular","response":"","error_code":163,"error_msg":"You may only export Reports of yourself or of Users in your Group.\n","warnings":[],"timestamp": ...}
```

...  ``¯\_(ツ)_/¯``