### PR TITLE
Use [String]::Join instead of loop-join

### DIFF
--- a/sc-iavm/misc/Auto-Purge Target IPs.ps1
+++ b/sc-iavm/misc/Auto-Purge Target IPs.ps1
@@ -151,10 +151,10 @@ $path = Get-FileName -initialDirectory (Get-Location) -filter "Nessus Results Fi
 # Get the targets...
 Write-Host -ForegroundColor Yellow "Give me text file with IPs to remove (one per line)..."
 $path = Get-FileName -initialDirectory (Get-Location) -filter "Text File with IPs (*.txt) | *.txt"
-$target_ip_addrs = Get-Content($path) -ErrorAction Stop
+$target_ip_file_content = Get-Content($path) -ErrorAction Stop
 
 # Sanity check:
-if (($nessusFile -eq $null) -or ($target_ip_addrs -eq $null)) { throw "Something happened..." }
+if (($nessusFile -eq $null) -or ($target_ip_file_content -eq $null)) { throw "Something happened..." }
 
 <### Change out the template IP for the new IP(s) (Lines 21, 4378, 4380) ###>
 # Line 21: NessusClientData_v2.Policy.Preferences.ServerPreferences.preference; Get the 'TARGET' name/value pair
@@ -163,38 +163,36 @@ $xml_node = $nessusFile.NessusClientData_v2.Policy.Preferences.ServerPreferences
 <# Replace Line 21 with the target(s); Format is a comma separated list of either single IP, or range
    e.g., 1.2.3.4,2.3.4.0-2.3.4.255
 #>
-$concatenated_ips = ""
-foreach ($line in $target_ip_addrs) {
+$progress = 0
+$target_ip_addrs = @()
+foreach ($line in $target_ip_file_content) {
+    Write-Progress -Activity "Reading in IP lines" -CurrentOperation $line -PercentComplete (100 * ($progress / $target_ip_file_content.Count ))
     if ([System.Net.IPAddress]::TryParse($line, [ref]'0.0.0.0')) {
         # Is the line itself an IP?
-        $concatenated_ips += $line + ","
+        $target_ip_addrs += $line
     }
     elseif ($line.Contains('/')) {
         # Maybe it is a CIDR range!?
         $cidr_split = $line.Split('/')
-        $result = Get-IPRange -ip $cidr_split[0] -cidr $cidr_split[1]
-        foreach ($entry in $result) {
-            $concatenated_ips += $entry + ","
-        }
+        $target_ip_addrs += Get-IPRange -ip $cidr_split[0] -cidr $cidr_split[1]
     }
     elseif ($line.Contains('-')) {
         # Or even a range?!
         $range_split = $line.Split('-')
-        $result = Get-IPRange -start $range_split[0] -end $range_split[1]
-        foreach ($entry in $result) {
-            $concatenated_ips += $entry + ","
-        }
+        $target_ip_addrs += Get-IPRange -start $range_split[0] -end $range_split[1]
     }
-    else {
-        # WHARRGARBL! No one here but us kittens. Skip this $line.
-    }
+    # No match? Then... WHARRGARBL! No one here but us kittens. Skip this $line.
+
+    $progress++
 }
+# Concatenation out here is more along the lines of O(1), instead of O(n) above.
+$concatenated_ips = [String]::Join(',', $target_ip_addrs)
+
 # We need IP addresses to continue, otherwise the SC backend will error out due to the malformed file.
 if ($concatenated_ips -eq "") {
     throw "No IP addresses found in the input file. Terminating execution."
 }
-$concatenated_ips = $concatenated_ips.TrimEnd(',')
-$target_ip_addrs = $concatenated_ips.Split(',')
+
 $xml_node.value = $concatenated_ips
 
 # Store the XML location/node of our template


### PR DESCRIPTION
Because why reinvent the wheel and use a foreach loop to manually join the string to a concatenated string? Let's use what the language gives us.

Execution time for this section reduced basically to O(1) instead of O(n), or whatever it was, now that we don't need to iterate over every IP in a CIDR/range ourselves.